### PR TITLE
Fixed 'overloaded function with no contextual type information' error

### DIFF
--- a/src/ravijit.cpp
+++ b/src/ravijit.cpp
@@ -272,9 +272,17 @@ static const luaL_Reg ravilib[] = {{"iscompiled", ravi_is_compiled},
 LUAMOD_API int raviopen_llvmjit(lua_State *L) {
   luaL_newlib(L, ravilib);
   /* faster calls some maths functions */
+  #ifdef __cplusplus
+  ravi_pushcfastcall(L, (void *)static_cast<double(*)(double)>(std::exp), RAVI_TFCF_D_D);
+  #else
   ravi_pushcfastcall(L, (void *)exp, RAVI_TFCF_D_D);
+  #endif
   lua_setfield(L, -2, "exp");
+  #ifdef __cplusplus
+  ravi_pushcfastcall(L, (void *)static_cast<double(*)(double)>(std::log), RAVI_TFCF_D_D);
+  #else
   ravi_pushcfastcall(L, (void *)log, RAVI_TFCF_D_D);
+  #endif
   lua_setfield(L, -2, "ln");
   return 1;
 }


### PR DESCRIPTION
I got this error with compiler "GNU 8.2.1" : 

```
/ravi/src/ravijit.cpp: In function ‘int raviopen_llvmjit(lua_State*)’:
/ravi/src/ravijit.cpp:294:33: error: overloaded function with no contextual type information
   ravi_pushcfastcall(L, (void *)exp, RAVI_TFCF_D_D);
                                 ^~~
/ravi/src/ravijit.cpp:296:33: error: overloaded function with no contextual type information
   ravi_pushcfastcall(L, (void *)log, RAVI_TFCF_D_D);
```
I added static_cast to an overloaded version of std::exp and std::log if the macro __cplusplus is defined, I chose the `double std::exp(double)` and `double std::log(double)` as this is the default exp / log in C stdlib.