### PR TITLE
Improve type deduction

### DIFF
--- a/src/lcode.c
+++ b/src/lcode.c
@@ -1278,7 +1278,17 @@ static void codeunexpval (FuncState *fs, OpCode op, expdesc *e, int line) {
       e->u.info = luaK_codeABC(fs, OP_LEN, 0, r, 0);
       if (e->ravi_type == RAVI_TARRAYINT || e->ravi_type == RAVI_TARRAYFLT || e->ravi_type == RAVI_TSTRING) {
         e->ravi_type = RAVI_TNUMINT;
-      } else {
+      } else if(e->ravi_type == RAVI_TTABLE) {
+        e->k = VRELOCABLE;
+        luaK_exp2anyreg(fs, e);
+        /* This is not incompatible with lua since a type annotation is require to get here or the table trivially has
+         * no metatable */
+        luaK_codeABC(fs, OP_RAVI_TOINT, e->u.info, 0, 0);
+        e->ravi_type = RAVI_TNUMINT;
+        luaK_fixline(fs, line);
+        return;
+      }
+      else {
         e->ravi_type = RAVI_TANY;
       }
       break;

--- a/src/lcode.c
+++ b/src/lcode.c
@@ -1278,7 +1278,7 @@ static void codeunexpval (FuncState *fs, OpCode op, expdesc *e, int line) {
       break;
     case OP_LEN:
       e->u.info = luaK_codeABC(fs, OP_LEN, 0, r, 0);
-      if (e->ravi_type == RAVI_TARRAYINT || e->ravi_type == RAVI_TARRAYFLT || e->ravi_type == RAVI_TSTRING) {
+      if (e->ravi_type == RAVI_TARRAYINT || e->ravi_type == RAVI_TARRAYFLT) {
         e->ravi_type = RAVI_TNUMINT;
       }
       else if (e->ravi_type == RAVI_TTABLE) {
@@ -1391,8 +1391,8 @@ static void codebinexpval (FuncState *fs, OpCode op,
     RAVI_GEN_INT_OP(SHR);
     case OP_CONCAT:
       e1->u.info = luaK_codeABC(fs, op, 0, rk1, rk2);
-      if ((e1->ravi_type == RAVI_TSTRING || e1->ravi_type == RAVI_TNUMINT || e1->ravi_type == RAVI_TNUMFLT) ||
-          (e2->ravi_type == RAVI_TSTRING || e2->ravi_type == RAVI_TNUMINT || e2->ravi_type == RAVI_TNUMFLT)) {
+      if ((e1->ravi_type == RAVI_TNUMINT || e1->ravi_type == RAVI_TNUMFLT) ||
+          (e2->ravi_type == RAVI_TNUMINT || e2->ravi_type == RAVI_TNUMFLT)) {
         e1->ravi_type = RAVI_TSTRING;
       }
       else {
@@ -1697,13 +1697,7 @@ void luaK_posfix (FuncState *fs, BinOpr op,
         SETARG_B(getinstruction(fs, e2), e1->u.info);
         DEBUG_CODEGEN(raviY_printf(fs, "[%d]* %o ; set A to %d\n", e2->u.info, getinstruction(fs,e2), e1->u.info));
         e1->k = VRELOCABLE; e1->u.info = e2->u.info;
-        if (e2->ravi_type == RAVI_TSTRING &&
-            (e1->ravi_type == RAVI_TSTRING || e1->ravi_type == RAVI_TNUMINT || e1->ravi_type == RAVI_TNUMFLT)) {
-          e1->ravi_type = RAVI_TSTRING;
-        }
-        else {
-          e1->ravi_type = RAVI_TANY;
-        }
+        e1->ravi_type = RAVI_TANY;
       }
       else {
         luaK_exp2nextreg(fs, e2);  /* operand must be on the 'stack' */

--- a/src/lcode.c
+++ b/src/lcode.c
@@ -1391,7 +1391,7 @@ static void codebinexpval (FuncState *fs, OpCode op,
     RAVI_GEN_INT_OP(SHR);
     case OP_CONCAT:
       e1->u.info = luaK_codeABC(fs, op, 0, rk1, rk2);
-      if ((e1->ravi_type == RAVI_TNUMINT || e1->ravi_type == RAVI_TNUMFLT) ||
+      if ((e1->ravi_type == RAVI_TNUMINT || e1->ravi_type == RAVI_TNUMFLT) &&
           (e2->ravi_type == RAVI_TNUMINT || e2->ravi_type == RAVI_TNUMFLT)) {
         e1->ravi_type = RAVI_TSTRING;
       }

--- a/src/lcode.c
+++ b/src/lcode.c
@@ -1292,9 +1292,9 @@ static void codeunexpval (FuncState *fs, OpCode op, expdesc *e, int line) {
         e->ravi_type = RAVI_TANY;
       }
       break;
-    case OPR_MINUS:
-      e->u.info = luaK_codeABC(fs, OPR_MINUS, 0, r, 0);
-      if(e->ravi_type != RAVI_TNUMINT && e->ravi_type != RAVI_TNUMFLT) {
+    case OP_UNM:
+      e->u.info = luaK_codeABC(fs, OP_UNM, 0, r, 0);
+      if (e->ravi_type != RAVI_TNUMINT && e->ravi_type != RAVI_TNUMFLT) {
         e->ravi_type = RAVI_TANY;
       }
       break;

--- a/src/lcode.c
+++ b/src/lcode.c
@@ -1116,9 +1116,10 @@ void luaK_goiftrue (FuncState *fs, expdesc *e) {
     }
     default: {
       if (e->ravi_type == RAVI_TNIL || e->ravi_type == RAVI_TANY || e->ravi_type == RAVI_TBOOLEAN) {
-        pc = jumponcond(fs, e, 0);  /* jump when false */
-      } else {
-        pc = NO_JUMP;  /* always true; do nothing */
+        pc = jumponcond(fs, e, 0); /* jump when false */
+      }
+      else {
+        pc = NO_JUMP; /* always true; do nothing */
       }
       break;
     }
@@ -1146,9 +1147,10 @@ void luaK_goiffalse (FuncState *fs, expdesc *e) {
     }
     default: {
       if (e->ravi_type == RAVI_TNIL) {
-        pc = NO_JUMP;  /* always false; do nothing */
-      } else {
-        pc = jumponcond(fs, e, 1);  /* jump if true */
+        pc = NO_JUMP; /* always false; do nothing */
+      }
+      else {
+        pc = jumponcond(fs, e, 1); /* jump if true */
       }
       break;
     }
@@ -1264,9 +1266,9 @@ static int constfolding (FuncState *fs, int op, expdesc *e1,
 static void codeunexpval (FuncState *fs, OpCode op, expdesc *e, int line) {
   int r = luaK_exp2anyreg(fs, e);  /* opcodes operate only on registers */
   freeexp(fs, e);
-  switch(op) {
+  switch (op) {
     case OP_BNOT:
-      if(e->ravi_type == RAVI_TNUMINT) {
+      if (e->ravi_type == RAVI_TNUMINT) {
         e->u.info = luaK_codeABC(fs, OP_RAVI_BNOT_I, 0, r, 0);
         e->ravi_type = RAVI_TNUMINT;
         break;
@@ -1278,7 +1280,8 @@ static void codeunexpval (FuncState *fs, OpCode op, expdesc *e, int line) {
       e->u.info = luaK_codeABC(fs, OP_LEN, 0, r, 0);
       if (e->ravi_type == RAVI_TARRAYINT || e->ravi_type == RAVI_TARRAYFLT || e->ravi_type == RAVI_TSTRING) {
         e->ravi_type = RAVI_TNUMINT;
-      } else if(e->ravi_type == RAVI_TTABLE) {
+      }
+      else if (e->ravi_type == RAVI_TTABLE) {
         e->k = VRELOCABLE;
         luaK_exp2anyreg(fs, e);
         /* This is not incompatible with lua since a type annotation is require to get here or the table trivially has
@@ -1322,10 +1325,10 @@ static void codebinexpval (FuncState *fs, OpCode op,
   int rk1 = luaK_exp2RK(fs, e1);
   freeexps(fs, e1, e2);
 
-#define RAVI_OPCODE_SPECIALIZED(op,t) OP_RAVI_##op##t
-#define RAVI_OPCODE_GENERIC(op,t) OP_##op
-#define RAVI_COMMUTATIVE(op,t) luaK_codeABC(fs, t(op,FI), 0, rk2, rk1)
-#define RAVI_NON_COMMUTATIVE(op,t) luaK_codeABC(fs, t(op,IF), 0, rk1, rk2)
+#define RAVI_OPCODE_SPECIALIZED(op, t) OP_RAVI_##op##t
+#define RAVI_OPCODE_GENERIC(op, t) OP_##op
+#define RAVI_COMMUTATIVE(op, t) luaK_codeABC(fs, t(op, FI), 0, rk2, rk1)
+#define RAVI_NON_COMMUTATIVE(op, t) luaK_codeABC(fs, t(op, IF), 0, rk1, rk2)
 #define RAVI_GEN_ARITH(op, co, ii, t)                          \
   case OP_##op:                                                \
     if (e1->ravi_type == RAVI_TNUMFLT) {                       \
@@ -1372,7 +1375,7 @@ static void codebinexpval (FuncState *fs, OpCode op,
       e1->ravi_type = RAVI_TANY;                                                 \
     }                                                                            \
     break
-  
+
   switch (op) {
     RAVI_GEN_ARITH(ADD, RAVI_COMMUTATIVE, RAVI_TNUMINT, RAVI_OPCODE_SPECIALIZED);
     RAVI_GEN_ARITH(SUB, RAVI_NON_COMMUTATIVE, RAVI_TNUMINT, RAVI_OPCODE_SPECIALIZED);
@@ -1652,12 +1655,15 @@ void luaK_posfix (FuncState *fs, BinOpr op,
       if (e1->ravi_type == RAVI_TNIL) {
         /* nil and something is still nil. */
         e2->ravi_type = RAVI_TNIL;
-      } else if (e1->ravi_type == RAVI_TBOOLEAN || e1->ravi_type == RAVI_TANY) {
+      }
+      else if (e1->ravi_type == RAVI_TBOOLEAN || e1->ravi_type == RAVI_TANY) {
         /* In these cases the 'and' can go both ways. */
         if (e2->ravi_type != e1->ravi_type)
           e2->ravi_type = RAVI_TANY;
-      } else {
-        /* Nothing to do here, since the first arg is always truish and therefore the second arg will be used every time. */
+      }
+      else {
+        /* Nothing to do here, since the first arg is always truish and therefore the second arg will be used every
+         * time. */
       }
       *e1 = *e2;
       break;
@@ -1667,12 +1673,15 @@ void luaK_posfix (FuncState *fs, BinOpr op,
       luaK_dischargevars(fs, e2);
       luaK_concat(fs, &e2->t, e1->t);
       if (e1->ravi_type == RAVI_TNIL) {
-        /* Nothing to do here, since the first arg is always truish and therefore the second arg will be used every time. */
-      } else if (e1->ravi_type == RAVI_TBOOLEAN || e1->ravi_type == RAVI_TANY) {
+        /* Nothing to do here, since the first arg is always truish and therefore the second arg will be used every
+         * time. */
+      }
+      else if (e1->ravi_type == RAVI_TBOOLEAN || e1->ravi_type == RAVI_TANY) {
         /* In these cases the 'or' can go both ways. */
         if (e2->ravi_type != e1->ravi_type)
           e2->ravi_type = RAVI_TANY;
-      } else {
+      }
+      else {
         /* In this case the first argument is truish and will be the return from 'or' */
         e2->ravi_type = e1->ravi_type;
       }
@@ -1688,9 +1697,11 @@ void luaK_posfix (FuncState *fs, BinOpr op,
         SETARG_B(getinstruction(fs, e2), e1->u.info);
         DEBUG_CODEGEN(raviY_printf(fs, "[%d]* %o ; set A to %d\n", e2->u.info, getinstruction(fs,e2), e1->u.info));
         e1->k = VRELOCABLE; e1->u.info = e2->u.info;
-        if (e2->ravi_type == RAVI_TSTRING && (e1->ravi_type == RAVI_TSTRING || e1->ravi_type == RAVI_TNUMINT || e1->ravi_type == RAVI_TNUMFLT)) {
+        if (e2->ravi_type == RAVI_TSTRING &&
+            (e1->ravi_type == RAVI_TSTRING || e1->ravi_type == RAVI_TNUMINT || e1->ravi_type == RAVI_TNUMFLT)) {
           e1->ravi_type = RAVI_TSTRING;
-        } else {
+        }
+        else {
           e1->ravi_type = RAVI_TANY;
         }
       }

--- a/src/lparser.c
+++ b/src/lparser.c
@@ -1758,18 +1758,7 @@ static BinOpr subexpr (LexState *ls, expdesc *v, int limit) {
     /* read sub-expression with higher priority */
     nextop = subexpr(ls, &v2, priority[op].right);
     DEBUG_EXPR(raviY_printf(ls->fs, "subexpr-> %e binop(%d) %e\n", v, (int)op, &v2));
-    /* 
-    The bool 'and' and 'or' operators preserve the type of the
-    expression that gets selected, so if these are both integer or number types
-    then we know result will be integer or number, else the result is
-    unpredictable so we set both expressions to RAVI_TANY
-    */
-    if (op == OPR_AND || op == OPR_OR) {
-      if (v->ravi_type != v2.ravi_type || (v->ravi_type != RAVI_TNUMINT && v->ravi_type != RAVI_TNUMFLT)) {
-        v->ravi_type = RAVI_TANY;
-        v2.ravi_type = RAVI_TANY;
-      }
-    }
+    
     luaK_posfix(ls->fs, op, v, &v2, line);
     DEBUG_EXPR(raviY_printf(ls->fs, "subexpr-> after posfix %e\n", v));
     op = nextop;

--- a/tests/language/ravi_tests1.ravi
+++ b/tests/language/ravi_tests1.ravi
@@ -1523,7 +1523,7 @@ print 'Test 58 OK'
 function x(s1: string, s2: string)
   return @string( s1 .. s2 )
 end
-check(x, 'TOSTRING', 'TOSTRING', 'MOVE', 'MOVE', 'CONCAT', 'RETURN', 'RETURN')
+check(x, 'TOSTRING', 'TOSTRING', 'MOVE', 'MOVE', 'CONCAT', 'TOSTRING', 'RETURN', 'RETURN')
 assert(x('a', 'b') == 'ab')
 compile(x)
 assert(x('a', 'b') == 'ab')

--- a/tests/language/ravi_tests1.ravi
+++ b/tests/language/ravi_tests1.ravi
@@ -1523,7 +1523,7 @@ print 'Test 58 OK'
 function x(s1: string, s2: string)
   return @string( s1 .. s2 )
 end
-check(x, 'TOSTRING', 'TOSTRING', 'MOVE', 'MOVE', 'CONCAT', 'TOSTRING', 'RETURN', 'RETURN')
+check(x, 'TOSTRING', 'TOSTRING', 'MOVE', 'MOVE', 'CONCAT', 'RETURN', 'RETURN')
 assert(x('a', 'b') == 'ab')
 compile(x)
 assert(x('a', 'b') == 'ab')
@@ -1699,8 +1699,8 @@ function x()
 end
 assert(ravitype(x()) == 'number[]')
 assert(x()[1] == 42.0)
-check(x, 'NEW_IARRAY', 'LOADK', 'SETLIST', 'TEST',
-  'JMP', 'NEW_FARRAY', 'LOADK', 'SETLIST', 'TOFARRAY',
+check(x, 'NEW_IARRAY', 'LOADK', 'SETLIST',
+  'NEW_FARRAY', 'LOADK', 'SETLIST',
   'RETURN', 'RETURN')
 print 'Test 74 OK'
 
@@ -1797,10 +1797,14 @@ print 'Test 83 OK'
 function x(x:number)
     return (~x)+1
 end
-check(x, 'TOFLT', 'BNOT', 'ADD', 'RETURN', 'RETURN')
+check(x, 'TOFLT', 'BNOT', 'ADDII', 'RETURN', 'RETURN')
 assert(x(1.0) == -1)
 compile(x)
 assert(x(1.0) == -1)
+function x(x:table)
+    return (~x)+1
+end
+check(x, 'TOTAB', 'BNOT', 'ADD', 'RETURN', 'RETURN')
 print 'Test 84 OK'
 
 -- Test that #() applied to non integer type produces any type


### PR DESCRIPTION
Some improvements with type deduction.

Some examples

| Expression | Old |Now|
| --- | --- | --- |
| -{} | RAVI_TTABLE | RAVI_TANY |
| #("") | RAVI_TANY | RAVI_TNUMINT |
| ~1.0 | RAVI_TANY | RAVI_TNUMINT |
| ""..1 | RAVI_TANY | RAVI_TSTRING |
| "" and 1 | RAVI_TANY | RAVI_TNUMINT |