### PR TITLE
Add `debug.registrytype(type, mt)` function

### DIFF
--- a/readthedocs/ravi-reference.rst
+++ b/readthedocs/ravi-reference.rst
@@ -171,15 +171,11 @@ The main use case for these annotations is to help with type-checking of larger 
 
 Examples::
 
-  -- Create a metatable
-  local mt = { __name='MyType'}
-
-  -- Register the metatable in Lua registry
-  debug.getregistry().MyType = mt
+  -- Register new type in Lua registry and get associated metatable
+  local mytype = debug.registertype("MyType", {__name='MyType'})
 
   -- Create an object and assign the metatable as its type
-  local t = {}
-  setmetatable(t, mt)
+  local t = setmetatable({}, mytype)
 
   -- Use the metatable name as the object's type
   function x(s: MyType) 

--- a/src/ldblib.c
+++ b/src/ldblib.c
@@ -434,6 +434,17 @@ static int db_traceback (lua_State *L) {
 }
 
 
+static int db_registertype (lua_State *L) {
+  const char *type = luaL_checkstring(L, 1);
+  luaL_checktype(L, 2, LUA_TTABLE);
+  lua_setfield(L, LUA_REGISTRYINDEX, type);
+  lua_pop(L, 1);
+  lua_pushvalue(L, LUA_REGISTRYINDEX);
+  lua_getfield(L, 1, type);
+  return 1;
+}
+
+
 static const luaL_Reg dblib[] = {
   {"debug", db_debug},
   {"getuservalue", db_getuservalue},
@@ -451,6 +462,7 @@ static const luaL_Reg dblib[] = {
   {"setmetatable", db_setmetatable},
   {"setupvalue", db_setupvalue},
   {"traceback", db_traceback},
+  {"registertype", db_registertype},
   {NULL, NULL}
 };
 


### PR DESCRIPTION
Hello!
I suggest to add a bit sugar and create separate function to register new type.

How it looks now:
```lua
  -- Create a metatable
  local mt = { __name='MyType'}

  -- Register the metatable in Lua registry
  debug.getregistry().MyType = mt
```

My suggestion:
```lua
  -- Register new type in Lua registry and get associated metatable
  local mytype = debug.registertype('MyType', { __name='MyType'}) -- returns metatable
  -- local mt = {__name='MyType'}; debug.registertype('MyType', mt); -- also acceptable
```
