### PR TITLE
Revive `boolean` type

### DIFF
--- a/readthedocs/ravi-reference.rst
+++ b/readthedocs/ravi-reference.rst
@@ -38,6 +38,8 @@ The supported type-annotations are as follows:
   denotes a Lua table
 ``string``
   denotes a string
+``boolean``
+  denotes a boolean
 ``closure``
   denotes a function
 ``Name [. Name]*``

--- a/src/lcode.h
+++ b/src/lcode.h
@@ -39,7 +39,7 @@ typedef enum BinOpr {
 /** RAVI change */
 typedef enum UnOpr { OPR_MINUS, OPR_BNOT, OPR_NOT, OPR_LEN, OPR_TO_INTEGER,
   OPR_TO_NUMBER, OPR_TO_INTARRAY, OPR_TO_NUMARRAY, OPR_TO_TABLE, OPR_TO_STRING, 
-  OPR_TO_CLOSURE, OPR_TO_TYPE, OPR_NOUNOPR } UnOpr;
+  OPR_TO_BOOLEAN, OPR_TO_CLOSURE, OPR_TO_TYPE, OPR_NOUNOPR } UnOpr;
 
 /* get (pointer to) instruction of given 'expdesc' */
 #define getinstruction(fs,e)	((fs)->f->code[(e)->u.info])

--- a/src/lopcodes.c
+++ b/src/lopcodes.c
@@ -112,6 +112,7 @@ LUAI_DDEF const char *const luaP_opnames[NUM_OPCODES+1] = {
   "TOFARRAY", /* A R(A) := to_arrayf(R(A)) */
   "TOTAB",     /* A R(A) := to_table(R(A)) */
   "TOSTRING",
+  "TOBOOLEAN",
   "TOCLOSURE",
   "TOTYPE",
 
@@ -256,6 +257,7 @@ LUAI_DDEF const lu_byte luaP_opmodes[NUM_OPCODES] = {
  ,opmode(0, 1, OpArgN, OpArgN, iABC)    /* OP_RAVI_TOFARRAY A R(A) := check_array_of_float(R(A)) */
  ,opmode(0, 1, OpArgN, OpArgN, iABC)    /* OP_RAVI_TOTAB A R(A) := check_table(R(A)) */
  ,opmode(0, 1, OpArgN, OpArgN, iABC)    /* OP_RAVI_TOSTRING */
+ ,opmode(0, 1, OpArgN, OpArgN, iABC)    /* OP_RAVI_TOBOOLEAN */
  ,opmode(0, 1, OpArgN, OpArgN, iABC)    /* OP_RAVI_TOCLOSURE */
  ,opmode(0, 1, OpArgK, OpArgN, iABx)    /* OP_RAVI_TOTYPE */
 

--- a/src/lopcodes.h
+++ b/src/lopcodes.h
@@ -223,6 +223,7 @@ OP_RAVI_TOIARRAY, /* A R(A) := to_arrayi(R(A)) */
 OP_RAVI_TOFARRAY, /* A R(A) := to_arrayf(R(A)) */
 OP_RAVI_TOTAB,    /* A R(A) := to_table(R(A)) */
 OP_RAVI_TOSTRING, /* A R(A) := assert_string(R(A)) */
+OP_RAVI_TOBOOLEAN, /* A R(A) := assert_string(R(A)) */
 OP_RAVI_TOCLOSURE, /* A R(A) := assert_closure(R(A)) */
 OP_RAVI_TOTYPE,  /* A R(A) := assert_usertype(R(A)), where usertype has metatable in Lua registry */
 

--- a/src/lparser.c
+++ b/src/lparser.c
@@ -639,9 +639,10 @@ static void ravi_code_typecoersion(LexState *ls, int reg, ravi_type_map tm,
     luaK_codeABx(ls->fs, OP_RAVI_TOTYPE, reg, luaK_stringK(ls->fs, typename));
   else if (tm == RAVI_TM_STRING_OR_NIL)
     luaK_codeABC(ls->fs, OP_RAVI_TOSTRING, reg, 0, 0);
+  else if (tm == RAVI_TM_BOOLEAN_OR_NIL)
+    luaK_codeABC(ls->fs, OP_RAVI_TOBOOLEAN, reg, 0, 0);
   else if (tm == RAVI_TM_FUNCTION_OR_NIL)
     luaK_codeABC(ls->fs, OP_RAVI_TOCLOSURE, reg, 0, 0);
-  // TODO coerse to boolean
 }
 
 /* RAVI code an instruction to initialize a scalar typed value
@@ -1279,8 +1280,8 @@ static ravi_type_map declare_localvar(LexState *ls, TString **pusertype) {
       tm = RAVI_TM_TABLE;
     else if (strcmp(str, "string") == 0)
       tm = RAVI_TM_STRING_OR_NIL;
-    //else if (strcmp(str, "boolean") == 0)
-    //  tm = RAVI_TM_BOOLEAN_OR_NIL;
+    else if (strcmp(str, "boolean") == 0)
+      tm = RAVI_TM_BOOLEAN_OR_NIL;
     else if (strcmp(str, "any") == 0)
       tm = RAVI_TM_ANY;
     else {
@@ -1458,7 +1459,7 @@ static void ravi_typecheck(LexState *ls, expdesc *v, ravi_type_map *var_types,
   /* if we are calling a function then convert return types */
   else if ((vartype == RAVI_TM_FLOAT || vartype == RAVI_TM_INTEGER ||
             vartype == RAVI_TM_FLOAT_ARRAY || vartype == RAVI_TM_INTEGER_ARRAY ||
-            vartype == RAVI_TM_TABLE || vartype == RAVI_TM_STRING_OR_NIL ||
+            vartype == RAVI_TM_TABLE || vartype == RAVI_TM_STRING_OR_NIL || vartype == RAVI_TM_BOOLEAN_OR_NIL ||
             vartype == RAVI_TM_FUNCTION_OR_NIL || vartype == RAVI_TM_USERDATA_OR_NIL) &&
             v->k == VCALL) {
     /* For local variable declarations that call functions e.g.
@@ -1488,7 +1489,8 @@ static void ravi_typecheck(LexState *ls, expdesc *v, ravi_type_map *var_types,
   }
   else if (vartype == RAVI_TM_STRING_OR_NIL ||
             vartype == RAVI_TM_FUNCTION_OR_NIL ||
-            vartype == RAVI_TM_USERDATA_OR_NIL) {
+            vartype == RAVI_TM_USERDATA_OR_NIL || 
+            vartype == RAVI_TM_BOOLEAN_OR_NIL) {
     TString *usertype = usertypes[n]; // NULL if var_types[n] is not userdata
     /* we need to make sure that a register is assigned to 'v'
       so that we can emit type assertion instructions. This would have 

--- a/src/lvm.c
+++ b/src/lvm.c
@@ -1331,6 +1331,7 @@ int luaV_execute (lua_State *L) {
     &&vmlabel(OP_RAVI_TOFARRAY),
     &&vmlabel(OP_RAVI_TOTAB),
     &&vmlabel(OP_RAVI_TOSTRING),
+    &&vmlabel(OP_RAVI_TOBOOLEAN),
     &&vmlabel(OP_RAVI_TOCLOSURE),
     &&vmlabel(OP_RAVI_TOTYPE),
     &&vmlabel(OP_RAVI_MOVEI),
@@ -2587,6 +2588,11 @@ int luaV_execute (lua_State *L) {
       vmcase(OP_RAVI_TOSTRING) {
         if (!ttisnil(ra) && RAVI_UNLIKELY(!ttisstring(ra)))
           luaG_runerror(L, "string expected");        
+        vmbreak;
+      }
+      vmcase(OP_RAVI_TOBOOLEAN) {
+        if (!ttisnil(ra) && RAVI_UNLIKELY(!ttisboolean(ra)))
+          luaG_runerror(L, "boolean expected");
         vmbreak;
       }
       vmcase(OP_RAVI_TOCLOSURE) {

--- a/src/ravi_jitshared.c
+++ b/src/ravi_jitshared.c
@@ -1659,6 +1659,19 @@ static void emit_op_tostring(struct function *fn, int A, int pc) {
   membuff_add_string(&fn->body, "}\n");
 }
 
+static void emit_op_toboolean(struct function *fn, int A, int pc) {
+  (void)pc;
+  emit_reg(fn, "ra", A);
+  membuff_add_string(&fn->body, "if (!ttisboolean(ra)) {\n");
+#if GOTO_ON_ERROR
+  membuff_add_fstring(&fn->body, " error_code = %d;\n", Error_string_expected);
+  membuff_add_string(&fn->body, " goto Lraise_error;\n");
+#else
+  membuff_add_fstring(&fn->body, " raviV_raise_error(L, %d);\n", Error_string_expected);
+#endif
+  membuff_add_string(&fn->body, "}\n");
+}
+
 static void emit_op_totype(struct function *fn, int A, int Bx, int pc) {
   (void)pc;
   emit_reg(fn, "ra", A);
@@ -2266,6 +2279,9 @@ bool raviJ_codegen(struct lua_State *L, struct Proto *p, struct ravi_compile_opt
       } break;
       case OP_RAVI_TOSTRING: {
         emit_op_tostring(&fn, A, pc);
+      } break;
+      case OP_RAVI_TOBOOLEAN: {
+        emit_op_toboolean(&fn, A, pc);
       } break;
       case OP_RAVI_TOCLOSURE: {
         emit_op_toclosure(&fn, A, pc);

--- a/tests/language/ravi_errors.ravi
+++ b/tests/language/ravi_errors.ravi
@@ -101,6 +101,7 @@ checkmessage('@string 1', 'unexpected symbol near @string') -- FIXME bad error m
 checkmessage('@MyType 1', "unexpected symbol near '@'") -- FIXME bad error message
 checkmessage('local function x(y: MyType) end x(1)', 'type mismatch: expected MyType')
 checkmessage('local function x(y: string) end x(1)', 'string expected')
+checkmessage('local function x(y: boolean) end x(1)', 'boolean expected')
 checkmessage('local function x(y: closure) end x(1)', 'closure expected')
 checkmessage('local function x() local s: string; s = 1 end', "Invalid assignment: string expected near 'end'")
 checkmessage('function x() local s: string; s = (function() return 1 end)() end; x()', 'string expected')


### PR DESCRIPTION
Hello!
I'm here to resurrect the `boolean` type. 
Looks like it was dead a long time ago and buried in source code.

As for current Ravi version, there is zombie `boolean` type. Look:
```lua
local function bool(b: boolean)
        print(b, ravitype(b))
end

bool(true)
```
`ravi: /home/ann/bool.ravi:0: type mismatch: expected boolean`

Literally, `boolean` type exists, but it just does not work -- nor true nor false are "not boolean".

--------------------------------------------------------------------------------------------------

After some necromancy, `boolean` shows signs of life.
```lua
local function bool(b: boolean)
	print(b, ravitype(b))
end

bool(true)
bool('world')
```
`true	boolean`
`src/ravi: /home/ann/bool.ravi:0: boolean expected`

That works too:
```lua
local b: boolean = true
b = 123
```
`src/ravi: b.ravi:4: Invalid assignment: boolean expected near <eof>`

But I could forget to add it somewhere, please, double check it. 