### PR TITLE
Fix/Restore `LUA_COMPAT_FLOATSTRING` and disable it by default

### DIFF
--- a/include/luaconf.h
+++ b/include/luaconf.h
@@ -411,7 +411,7 @@
 ** This macro is not on by default even in compatibility mode,
 ** because this is not really an incompatibility.
 */
-#define LUA_COMPAT_FLOATSTRING
+/* #define LUA_COMPAT_FLOATSTRING */
 
 /* }================================================================== */
 

--- a/src/lobject.c
+++ b/src/lobject.c
@@ -377,10 +377,12 @@ static int tostringbuff (TValue *obj, char *buff) {
     len = lua_integer2str(buff, MAXNUMBER2STR, ivalue(obj));
   else {
     len = lua_number2str(buff, MAXNUMBER2STR, fltvalue(obj));
+#if !defined(LUA_COMPAT_FLOATSTRING)
     if (buff[strspn(buff, "-0123456789")] == '\0') {  /* looks like an int? */
       buff[len++] = lua_getlocaledecpoint();
       buff[len++] = '0';  /* adds '.0' to result */
     }
+#endif
   }
   return len;
 }


### PR DESCRIPTION
This define was broken/non-functional because of a Lua 5.4 backport not taking it into account, also the reason I'm disabling this is because it isn't that helpful or useful (it makes it harder to tell if a number is a float/double internally for what seems like no good reason) and hasn't worked for years in Ravi anyways.

The commit that broke this in the first place was https://github.com/dibyendumajumdar/ravi/commit/22d84e74d0a4faf8c9d8bd456f340579eb1b1518